### PR TITLE
Updates JS code to work with new UI

### DIFF
--- a/src/ScrapeTikTokComments.js
+++ b/src/ScrapeTikTokComments.js
@@ -1,18 +1,18 @@
 with({
     copy
 }) {
-    var AllCommentsXPath                 = '/html/body/div/div[2]/div[3]/div[2]/div[3]';
-    var level2CommentsXPath              = '/html/body/div/div[2]/div[3]/div[2]/div[3]/div/div[2]/div/a';
+    var allCommentsXPath                 = '//div[contains(@class, "DivCommentContentContainer")]';
+    var level2CommentsXPath              = '//div[contains(@class, "DivReplyContainer")]';
 
-    var publisherProfileUrlXPath         = '/html/body/div/div[2]/div[3]/div[2]/div[1]/a[1]';
-    var nicknameAndTimePublishedAgoXPath = '/html/body/div/div[2]/div[3]/div[2]/div[1]/a[2]/span[2]';
+    var publisherProfileUrlXPath         = '/html/body/div[2]/div[2]/div[2]/div[2]/div[3]/div[2]/div[1]/a[2]';
+    var nicknameAndTimePublishedAgoXPath = '/html/body/div[2]/div[2]/div[2]/div[2]/div[3]/div[2]/div[1]/a[2]/span[2]';
 
-    var postUrlXPath                     = '/html/body/div/div[2]/div[3]/div[2]/div[2]/div[2]/div[2]/p';
-    var likeCountXPath                   = '/html/body/div/div[2]/div[3]/div[2]/div[2]/div[2]/div[1]/div[1]/button[1]/strong';
-    var descriptionXPath                 = '/html/body/div/div[2]/div[3]/div[2]/div[2]/div[1]';
-    var tiktokNumberOfCommentsXPath      = '/html/body/div/div[2]/div[3]/div[2]/div[2]/div[2]/div[1]/div[1]/button[2]/strong';
+    var postUrlXPath                     = '/html/body/div[2]/div[2]/div[2]/div[2]/div[3]/div[2]/div[2]/div[2]/div[2]/p';
+    var likeCountXPath                   = '/html/body/div[2]/div[2]/div[2]/div[2]/div[3]/div[2]/div[2]/div[2]/div[1]/div[1]/button[1]/strong';
+    var descriptionXPath                 = '/html/body/div[2]/div[2]/div[2]/div[2]/div[3]/div[2]/div[2]/div[1]';
+    var tiktokNumberOfCommentsXPath      = '/html/body/div[2]/div[2]/div[2]/div[2]/div[3]/div[2]/div[2]/div[2]/div[1]/div[1]/button[2]/strong';
 
-    var readMoreDivXPath                 = '/html/body/div/div[2]/div[3]/div[2]/div[3]/div/div[2]/div/p[1]/text()/..';
+    var viewMoreDivXPath                 = '//p[contains(@class, "PReplyAction") and contains(., "View")]';
 
     // more reliable than querySelector
     function getElementsByXPath(xpath, parent)
@@ -27,11 +27,19 @@ with({
     }
 
     function getAllComments(){
-        return getElementsByXPath(AllCommentsXPath)[0].children;
+        return getElementsByXPath(allCommentsXPath);
     }
 
     function quoteString(s) {
         return '"' + String(s).replaceAll('"', '""') + '"';
+    }
+
+    function getNickname(comment) {
+        return getElementsByXPath('./div[1]/a', comment)[0].outerText;
+    }
+
+    function isReply(comment) {
+        return comment.parentElement.className.includes('Reply')
     }
 
     function formatDate(strDate) {
@@ -52,17 +60,18 @@ with({
     }
 
     function csvFromComment(comment) {
-        nickname = getElementsByXPath('./div[1]/a', comment)[0].outerText;
+        nickname = getNickname(comment);
         user = getElementsByXPath('./a', comment)[0]['href'].split('?')[0].split('/')[3].slice(1);
         commentText = getElementsByXPath('./div[1]/p', comment)[0].outerText;
         timeCommentedAgo = formatDate(getElementsByXPath('./div[1]/p[2]/span', comment)[0].outerText);
         commentLikesCount = getElementsByXPath('./div[2]', comment)[0].outerText;
         pic = getElementsByXPath('./a/span/img', comment)[0]['src'];
-        return quoteString(nickname) + ',' + quoteString(user) + ',' + 'https://example.com' + ',' + quoteString(commentText) + ',' + timeCommentedAgo + ',' + commentLikesCount + ',' + quoteString(pic);
+        return quoteString(nickname) + ',' + quoteString(user) + ',' + 'https://example.com' + ',' 
+		     + quoteString(commentText) + ',' + timeCommentedAgo + ',' + commentLikesCount + ',' + quoteString(pic);
     }
 
     // Loading 1st level comments
-    var loadingCommentsBuffer = 30; // increase buffer if loading comments takes long and the loop break too soon
+    var loadingCommentsBuffer = 30; // increase buffer if loading comments takes long and the loop breaks too soon
     var numOfcommentsBeforeScroll = getAllComments().length;
     while (loadingCommentsBuffer > 0) {
 
@@ -85,15 +94,15 @@ with({
         // Wait 0.3 seconds.
         await new Promise(r => setTimeout(r, 300));
     }
-    console.log('Openend all 1st level comments');
+    console.log('Opened all 1st level comments');
 
 
     // Loading 2nd level comments
     loadingCommentsBuffer = 5; // increase buffer if loading comments takes long and the loop break too soon
     while (loadingCommentsBuffer > 0) {
-        readMoreDivs = getElementsByXPath(readMoreDivXPath);
+        readMoreDivs = getElementsByXPath(viewMoreDivXPath);
         for (var i = 0; i < readMoreDivs.length; i++) {
-            readMoreDivs[i].click()
+            readMoreDivs[i].click();
         }
 
         await new Promise(r => setTimeout(r, 500));
@@ -104,17 +113,17 @@ with({
         }
         console.log('Buffer ' + loadingCommentsBuffer);
     }
-    console.log('Openened all 2nd level comments');
+    console.log('Opened all 2nd level comments');
 
 
     // Reading all comments, extracting and converting the data to csv
     var comments = getAllComments();
+    var level2commentsLength = getElementsByXPath(level2CommentsXPath).length;
 
     var publisherProfileUrl = getElementsByXPath(publisherProfileUrlXPath)[0]['href'].split('?')[0];
     var nicknameAndPublishedAgoTime = getElementsByXPath(nicknameAndTimePublishedAgoXPath)[0].outerText.replaceAll('\n', ' ').split(' · ');
-    var level2commentsLength = getElementsByXPath(level2CommentsXPath).length;
 
-    var commentNumberDifference = Math.abs(getElementsByXPath(tiktokNumberOfCommentsXPath)[0].outerText - (comments.length + level2commentsLength))
+    var commentNumberDifference = Math.abs(getElementsByXPath(tiktokNumberOfCommentsXPath)[0].outerText - (comments.length));
 
 
     var csv = 'Now,' + Date() + '\n';
@@ -125,29 +134,35 @@ with({
     csv += 'Publish Time,' + formatDate(nicknameAndPublishedAgoTime[1]) + '\n'; // jsx removable
     csv += 'Post Likes,' + getElementsByXPath(likeCountXPath)[0].outerText + '\n'; // jsx removable
     csv += 'Description,' + quoteString(getElementsByXPath(descriptionXPath)[0].outerText) + '\n';
-    csv += 'Number of 1st level comments,' + comments.length + '\n';
+    csv += 'Number of 1st level comments,' + comments.length - level2commentsLength + '\n';
     csv += 'Number of 2nd level comments,' + level2commentsLength + '\n';
-    csv += '"Total Comments (actual, in this list, rendered in the comment section (needs all comments to be loaded!))",' + (comments.length + level2commentsLength) + '\n';
+    csv += '"Total Comments (actual, in this list, rendered in the comment section (needs all comments to be loaded!))",' + (comments.length) + '\n';
     csv += "Total Comments (which TikTok tells you; it's too high most of the time when dealing with many comments OR way too low because TikTok limits the number of comments to prevent scraping)," + getElementsByXPath(tiktokNumberOfCommentsXPath)[0].outerText + '\n';
     csv += "Difference," + commentNumberDifference + '\n';
-    csv += 'Comment Number (ID),Nickname,User @,User URL,Comment Text,Time,Likes,Profile Picture URL,Is 2nd Level Comment,Replied To,Number of replies\n';
-    var count = 1;
+    csv += 'Comment Number (ID),Nickname,User @,User URL,Comment Text,Time,Likes,Profile Picture URL,Is 2nd Level Comment,User Replied To,Number of Replies\n';
 
+    var count = 1;
+    var totalReplies = 0;
+    var repliesSeen = 1;
     for (var i = 0; i < comments.length; i++) {
-        level1comment = comments[i].children[0]
-        more = comments[i].children[1]
-        if (typeof more !== 'undefined') {
-            more = [...more.children].slice(0,-1);
-            numberOfReplies = more.length;
-        } else {
-            numberOfReplies = 0;
+        csv += count + ',' + csvFromComment(comments[i]) + ',';
+        if (i > 0 && isReply(comments[i])) {
+            csv += "Yes," + quoteString(getNickname(comments[i - repliesSeen])) + ',0';
+            repliesSeen += 1;
         }
-        csv += count + ',' + csvFromComment(level1comment) + ',No,---,' + numberOfReplies + '\n';
-        repliedTo = getElementsByXPath('./a', level1comment)[0]['href'].split('?')[0].split('/')[3].slice(1);
-        for (j = 0; j < numberOfReplies; j++) {
-            count++;
-            csv += count + ',' + csvFromComment(more[j]) + ',Yes,' + repliedTo + ',---\n';
+        else {
+            csv += 'No,---,';
+            totalReplies = 0;
+            repliesSeen = 1;
+            for (var j = 1; j < comments.length - i; j++) {
+                if (!isReply(comments[i + j])) {
+                    break;
+                }
+                totalReplies += 1;
+            }
+            csv += totalReplies;
         }
+        csv += '\n';
         count++;
     }
     var apparentCommentNumber = getElementsByXPath(tiktokNumberOfCommentsXPath)[0].outerText;

--- a/src/ScrapeTikTokComments.js
+++ b/src/ScrapeTikTokComments.js
@@ -8,13 +8,13 @@ with({
     var publisherProfileUrlXPath         = '//span[contains(@class, "SpanUniqueId")]';
     var nicknameAndTimePublishedAgoXPath = '//span[contains(@class, "SpanOtherInfos")]';
 
-	// we will filter these later because we have to handle them differently depending on what layout we have
+    // we will filter these later because we have to handle them differently depending on what layout we have
     var likesCommentsSharesXPath         = "//strong[contains(@class, 'StrongText')]";
-	
+
     var postUrlXPath                     = '//div[contains(@class, "CopyLinkText")]'
     var descriptionXPath                 = '//h4[contains(@class, "H4Link")]/preceding-sibling::div'
 
-	// we need "View" or else this catches "Hide" too
+    // we need "View" or else this catches "Hide" too
     var viewMoreDivXPath                 = '//p[contains(@class, "PReplyAction") and contains(., "View")]';
 
     // more reliable than querySelector
@@ -45,7 +45,7 @@ with({
         return comment.parentElement.className.includes('Reply')
     }
 
-	// if there's an actual date, formats it as DD-MM-YYYY (though TikTok displays it as MM-DD)
+    // if there's an actual date, formats it as DD-MM-YYYY (though TikTok displays it as MM-DD)
     function formatDate(strDate) {
         if (typeof strDate !== 'undefined' && strDate !== null) {
             f = strDate.split('-');
@@ -69,9 +69,9 @@ with({
         commentText = getElementsByXPath('./div[1]/p', comment)[0].outerText;
         timeCommentedAgo = formatDate(getElementsByXPath('./div[1]/p[2]/span', comment)[0].outerText);
         commentLikesCount = getElementsByXPath('./div[2]', comment)[0].outerText;
-        pic = getElementsByXPath('./a/span/img', comment)[0]['src'];
-        return quoteString(nickname) + ',' + quoteString(user) + ',' + 'https://www.tiktok.com/@' + user + ',' 
-		     + quoteString(commentText) + ',' + timeCommentedAgo + ',' + commentLikesCount + ',' + quoteString(pic);
+        pic = getElementsByXPath('./a/span/img', comment)[0] ? getElementsByXPath('./a/span/img', comment)[0]['src'] : "N/A";
+        return quoteString(nickname) + ',' + quoteString(user) + ',' + 'https://www.tiktok.com/@' + user + ','
+             + quoteString(commentText) + ',' + timeCommentedAgo + ',' + commentLikesCount + ',' + quoteString(pic);
     }
 
     // Loading 1st level comments
@@ -89,9 +89,9 @@ with({
         if (numOfcommentsAftScroll !== numOfcommentsBeforeScroll) {
             loadingCommentsBuffer = 15;
         } else {
-			// direct URLs can get jammed up because there's a recommended videos list that sometimes scrolls first, so scroll the div just in case
-			commentsDiv = getElementsByXPath(commentsDivXPath)[0]
-			commentsDiv.scrollIntoView(false);
+            // direct URLs can get jammed up because there's a recommended videos list that sometimes scrolls first, so scroll the div just in case
+            commentsDiv = getElementsByXPath(commentsDivXPath)[0]
+            commentsDiv.scrollIntoView(false);
             loadingCommentsBuffer--;
         };
         numOfcommentsBeforeScroll = numOfcommentsAftScroll;
@@ -128,15 +128,15 @@ with({
     var publisherProfileUrl = getElementsByXPath(publisherProfileUrlXPath)[0].outerText;
     var nicknameAndTimePublishedAgo = getElementsByXPath(nicknameAndTimePublishedAgoXPath)[0].outerText.replaceAll('\n', ' ').split(' · ');
 
-	// direct URLs don't include a place to copy the link (since it'd be redundant) so just grab the actual page URL
-	var url = window.location.href.split('?')[0]
-	// hashtags use the StrongText tag in addition to like/comment/share count, so filter those out
-	var likesCommentsShares = getElementsByXPath(likesCommentsSharesXPath).filter((element) => { return !element.outerText.includes('\#') })
-	var likes = likesCommentsShares[0].outerText;
-	var totalComments = likesCommentsShares[1].outerText;
-	
-	// the pop-up search window interface doesn't include shares
-	var shares = likesCommentsShares[2] ? likesCommentsShares[2].outerText : "N/A";
+    // direct URLs don't include a place to copy the link (since it'd be redundant) so just grab the actual page URL
+    var url = window.location.href.split('?')[0]
+    // hashtags use the StrongText tag in addition to like/comment/share count, so filter those out
+    var likesCommentsShares = getElementsByXPath(likesCommentsSharesXPath).filter((element) => { return !element.outerText.includes('\#') })
+    var likes = likesCommentsShares[0].outerText;
+    var totalComments = likesCommentsShares[1].outerText;
+
+    // the pop-up search window interface doesn't include shares
+    var shares = likesCommentsShares[2] ? likesCommentsShares[2].outerText : "N/A";
     var commentNumberDifference = Math.abs(parseInt(totalComments) - (comments.length));
 
 
@@ -146,8 +146,8 @@ with({
     csv += 'Publisher @,' + publisherProfileUrl + '\n';
     csv += 'Publisher URL,' + "https://www.tiktok.com/@" + publisherProfileUrl + '\n';
     csv += 'Publish Time,' + formatDate(nicknameAndTimePublishedAgo[1]) + '\n';
-    csv += 'Post Likes,' + likes + '\n'; 
-    csv += 'Post Shares,' + shares + '\n'; 
+    csv += 'Post Likes,' + likes + '\n';
+    csv += 'Post Shares,' + shares + '\n';
     csv += 'Description,' + quoteString(getElementsByXPath(descriptionXPath)[0].outerText) + '\n';
     csv += 'Number of 1st level comments,' + (comments.length - level2CommentsLength) + '\n';
     csv += 'Number of 2nd level comments,' + level2CommentsLength + '\n';
@@ -169,7 +169,7 @@ with({
             csv += 'No,---,';
             totalReplies = 0;
             repliesSeen = 1;
-			// Replies always come after the first comment, so look ahead until we reach another top-level comment
+            // Replies always come after the first comment, so look ahead until we reach another top-level comment
             for (var j = 1; j < comments.length - i; j++) {
                 if (!isReply(comments[i + j])) {
                     break;

--- a/src/ScrapeTikTokComments.js
+++ b/src/ScrapeTikTokComments.js
@@ -63,6 +63,14 @@ with({
         }
     }
 
+    function extractNumericStats() {
+        var strongTags = getElementsByXPath(likesCommentsSharesXPath);
+        // the StrongText class is used on lots of things that aren't likes or comments; the last two or three are what we need
+		// if it's a direct URL, shares are displayed, so we want the last three; if not, we only want the last two
+        likesCommentsShares = parseInt(strongTags[(strongTags.length - 3)].outerText) ? strongTags.slice(-3) : strongTags.slice(-2);
+        return likesCommentsShares;
+    }
+
     function csvFromComment(comment) {
         nickname = getNickname(comment);
         user = getElementsByXPath('./a', comment)[0]['href'].split('?')[0].split('/')[3].slice(1);
@@ -90,7 +98,7 @@ with({
             loadingCommentsBuffer = 15;
         } else {
             // direct URLs can get jammed up because there's a recommended videos list that sometimes scrolls first, so scroll the div just in case
-            commentsDiv = getElementsByXPath(commentsDivXPath)[0]
+            commentsDiv = getElementsByXPath(commentsDivXPath)[0];
             commentsDiv.scrollIntoView(false);
             loadingCommentsBuffer--;
         };
@@ -130,8 +138,7 @@ with({
 
     // direct URLs don't include a place to copy the link (since it'd be redundant) so just grab the actual page URL
     var url = window.location.href.split('?')[0]
-    // hashtags use the StrongText tag in addition to like/comment/share count, so filter those out
-    var likesCommentsShares = getElementsByXPath(likesCommentsSharesXPath).filter((element) => { return !element.outerText.includes('\#') })
+    var likesCommentsShares = extractNumericStats();
     var likes = likesCommentsShares[0].outerText;
     var totalComments = likesCommentsShares[1].outerText;
 
@@ -151,7 +158,7 @@ with({
     csv += 'Description,' + quoteString(getElementsByXPath(descriptionXPath)[0].outerText) + '\n';
     csv += 'Number of 1st level comments,' + (comments.length - level2CommentsLength) + '\n';
     csv += 'Number of 2nd level comments,' + level2CommentsLength + '\n';
-    csv += '"Total Comments (actual, in this list, rendered in the comment section (needs all comments to be loaded!))",' + (comments.length) + '\n';
+    csv += '"Total Comments (actual, in this list, rendered in the comment section; needs all comments to be loaded!)",' + (comments.length) + '\n';
     csv += "Total Comments (which TikTok tells you; it's too high most of the time when dealing with many comments OR way too low because TikTok limits the number of comments to prevent scraping)," + totalComments + '\n';
     csv += "Difference," + commentNumberDifference + '\n';
     csv += 'Comment Number (ID),Nickname,User @,User URL,Comment Text,Time,Likes,Profile Picture URL,Is 2nd Level Comment,User Replied To,Number of Replies\n';

--- a/src/ScrapeTikTokComments.js
+++ b/src/ScrapeTikTokComments.js
@@ -1,17 +1,20 @@
 with({
     copy
 }) {
+    var commentsDivXPath                 = '//div[contains(@class, "DivCommentListContainer")]';
     var allCommentsXPath                 = '//div[contains(@class, "DivCommentContentContainer")]';
     var level2CommentsXPath              = '//div[contains(@class, "DivReplyContainer")]';
 
-    var publisherProfileUrlXPath         = '/html/body/div[2]/div[2]/div[2]/div[2]/div[3]/div[2]/div[1]/a[2]';
-    var nicknameAndTimePublishedAgoXPath = '/html/body/div[2]/div[2]/div[2]/div[2]/div[3]/div[2]/div[1]/a[2]/span[2]';
+    var publisherProfileUrlXPath         = '//span[contains(@class, "SpanUniqueId")]';
+    var nicknameAndTimePublishedAgoXPath = '//span[contains(@class, "SpanOtherInfos")]';
 
-    var postUrlXPath                     = '/html/body/div[2]/div[2]/div[2]/div[2]/div[3]/div[2]/div[2]/div[2]/div[2]/p';
-    var likeCountXPath                   = '/html/body/div[2]/div[2]/div[2]/div[2]/div[3]/div[2]/div[2]/div[2]/div[1]/div[1]/button[1]/strong';
-    var descriptionXPath                 = '/html/body/div[2]/div[2]/div[2]/div[2]/div[3]/div[2]/div[2]/div[1]';
-    var tiktokNumberOfCommentsXPath      = '/html/body/div[2]/div[2]/div[2]/div[2]/div[3]/div[2]/div[2]/div[2]/div[1]/div[1]/button[2]/strong';
+	// we will filter these later because we have to handle them differently depending on what layout we have
+    var likesCommentsSharesXPath         = "//strong[contains(@class, 'StrongText')]";
+	
+    var postUrlXPath                     = '//div[contains(@class, "CopyLinkText")]'
+    var descriptionXPath                 = '//h4[contains(@class, "H4Link")]/preceding-sibling::div'
 
+	// we need "View" or else this catches "Hide" too
     var viewMoreDivXPath                 = '//p[contains(@class, "PReplyAction") and contains(., "View")]';
 
     // more reliable than querySelector
@@ -42,6 +45,7 @@ with({
         return comment.parentElement.className.includes('Reply')
     }
 
+	// if there's an actual date, formats it as DD-MM-YYYY (though TikTok displays it as MM-DD)
     function formatDate(strDate) {
         if (typeof strDate !== 'undefined' && strDate !== null) {
             f = strDate.split('-');
@@ -52,7 +56,7 @@ with({
             } else if (f.length == 3) {
                 return f[2] + '-' + f[1] + '-' + f[0];
             } else {
-                return 'Malformed Date';
+                return 'Malformed date';
             }
         } else {
             return 'No date';
@@ -77,7 +81,6 @@ with({
 
         allComments = getAllComments();
         lastComment = allComments[allComments.length - 1];
-        // Scroll last element into view = scrolling to bottom of comment page
         lastComment.scrollIntoView(false);
 
         numOfcommentsAftScroll = getAllComments().length;
@@ -86,6 +89,9 @@ with({
         if (numOfcommentsAftScroll !== numOfcommentsBeforeScroll) {
             loadingCommentsBuffer = 15;
         } else {
+			// direct URLs can get jammed up because there's a recommended videos list that sometimes scrolls first, so scroll the div just in case
+			commentsDiv = getElementsByXPath(commentsDivXPath)[0]
+			commentsDiv.scrollIntoView(false);
             loadingCommentsBuffer--;
         };
         numOfcommentsBeforeScroll = numOfcommentsAftScroll;
@@ -98,7 +104,7 @@ with({
 
 
     // Loading 2nd level comments
-    loadingCommentsBuffer = 5; // increase buffer if loading comments takes long and the loop break too soon
+    loadingCommentsBuffer = 5; // increase buffer if loading comments takes long and the loop breaks too soon
     while (loadingCommentsBuffer > 0) {
         readMoreDivs = getElementsByXPath(viewMoreDivXPath);
         for (var i = 0; i < readMoreDivs.length; i++) {
@@ -118,32 +124,41 @@ with({
 
     // Reading all comments, extracting and converting the data to csv
     var comments = getAllComments();
-    var level2commentsLength = getElementsByXPath(level2CommentsXPath).length;
+    var level2CommentsLength = getElementsByXPath(level2CommentsXPath).length;
+    var publisherProfileUrl = getElementsByXPath(publisherProfileUrlXPath)[0].outerText;
+    var nicknameAndTimePublishedAgo = getElementsByXPath(nicknameAndTimePublishedAgoXPath)[0].outerText.replaceAll('\n', ' ').split(' · ');
 
-    var publisherProfileUrl = getElementsByXPath(publisherProfileUrlXPath)[0]['href'].split('?')[0];
-    var nicknameAndPublishedAgoTime = getElementsByXPath(nicknameAndTimePublishedAgoXPath)[0].outerText.replaceAll('\n', ' ').split(' · ');
-
-    var commentNumberDifference = Math.abs(getElementsByXPath(tiktokNumberOfCommentsXPath)[0].outerText - (comments.length));
+	// direct URLs don't include a place to copy the link (since it'd be redundant) so just grab the actual page URL
+	var url = window.location.href.split('?')[0]
+	// hashtags use the StrongText tag in addition to like/comment/share count, so filter those out
+	var likesCommentsShares = getElementsByXPath(likesCommentsSharesXPath).filter((element) => { return !element.outerText.includes('\#') })
+	var likes = likesCommentsShares[0].outerText;
+	var totalComments = likesCommentsShares[1].outerText;
+	
+	// the pop-up search window interface doesn't include shares
+	var shares = likesCommentsShares[2] ? likesCommentsShares[2].outerText : "N/A";
+    var commentNumberDifference = Math.abs(parseInt(totalComments) - (comments.length));
 
 
     var csv = 'Now,' + Date() + '\n';
-    csv += 'Post URL,' + getElementsByXPath(postUrlXPath)[0].outerText.split('?')[0] + '\n';
-    csv += 'Publisher Nickname,' + nicknameAndPublishedAgoTime[0] + '\n';
-    csv += 'Publisher URL,' + publisherProfileUrl + '\n';
-    csv += 'Publisher @,' + publisherProfileUrl.split('/')[3].slice(1) + '\n';
-    csv += 'Publish Time,' + formatDate(nicknameAndPublishedAgoTime[1]) + '\n'; // jsx removable
-    csv += 'Post Likes,' + getElementsByXPath(likeCountXPath)[0].outerText + '\n'; // jsx removable
+    csv += 'Post URL,' + url + '\n';
+    csv += 'Publisher Nickname,' + nicknameAndTimePublishedAgo[0] + '\n';
+    csv += 'Publisher @,' + publisherProfileUrl + '\n';
+    csv += 'Publisher URL,' + "https://www.tiktok.com/@" + publisherProfileUrl + '\n';
+    csv += 'Publish Time,' + formatDate(nicknameAndTimePublishedAgo[1]) + '\n';
+    csv += 'Post Likes,' + likes + '\n'; 
+    csv += 'Post Shares,' + shares + '\n'; 
     csv += 'Description,' + quoteString(getElementsByXPath(descriptionXPath)[0].outerText) + '\n';
-    csv += 'Number of 1st level comments,' + comments.length - level2commentsLength + '\n';
-    csv += 'Number of 2nd level comments,' + level2commentsLength + '\n';
+    csv += 'Number of 1st level comments,' + (comments.length - level2CommentsLength) + '\n';
+    csv += 'Number of 2nd level comments,' + level2CommentsLength + '\n';
     csv += '"Total Comments (actual, in this list, rendered in the comment section (needs all comments to be loaded!))",' + (comments.length) + '\n';
-    csv += "Total Comments (which TikTok tells you; it's too high most of the time when dealing with many comments OR way too low because TikTok limits the number of comments to prevent scraping)," + getElementsByXPath(tiktokNumberOfCommentsXPath)[0].outerText + '\n';
+    csv += "Total Comments (which TikTok tells you; it's too high most of the time when dealing with many comments OR way too low because TikTok limits the number of comments to prevent scraping)," + totalComments + '\n';
     csv += "Difference," + commentNumberDifference + '\n';
     csv += 'Comment Number (ID),Nickname,User @,User URL,Comment Text,Time,Likes,Profile Picture URL,Is 2nd Level Comment,User Replied To,Number of Replies\n';
 
     var count = 1;
     var totalReplies = 0;
-    var repliesSeen = 1;
+    var repliesSeen = 1; // Offset of replies from corresponding parent comment
     for (var i = 0; i < comments.length; i++) {
         csv += count + ',' + csvFromComment(comments[i]) + ',';
         if (i > 0 && isReply(comments[i])) {
@@ -154,6 +169,7 @@ with({
             csv += 'No,---,';
             totalReplies = 0;
             repliesSeen = 1;
+			// Replies always come after the first comment, so look ahead until we reach another top-level comment
             for (var j = 1; j < comments.length - i; j++) {
                 if (!isReply(comments[i + j])) {
                     break;
@@ -165,7 +181,7 @@ with({
         csv += '\n';
         count++;
     }
-    var apparentCommentNumber = getElementsByXPath(tiktokNumberOfCommentsXPath)[0].outerText;
+    var apparentCommentNumber = parseInt(totalComments);
     console.log('Number of magically missing comments (not rendered in the comment section): ' + (apparentCommentNumber - count + 1) + ' (you have ' + (count - 1) + ' of ' + apparentCommentNumber + ')');
     console.log('CSV copied to clipboard!');
 

--- a/src/ScrapeTikTokComments.js
+++ b/src/ScrapeTikTokComments.js
@@ -66,7 +66,7 @@ with({
         timeCommentedAgo = formatDate(getElementsByXPath('./div[1]/p[2]/span', comment)[0].outerText);
         commentLikesCount = getElementsByXPath('./div[2]', comment)[0].outerText;
         pic = getElementsByXPath('./a/span/img', comment)[0]['src'];
-        return quoteString(nickname) + ',' + quoteString(user) + ',' + 'https://example.com' + ',' 
+        return quoteString(nickname) + ',' + quoteString(user) + ',' + 'https://www.tiktok.com/@' + user + ',' 
 		     + quoteString(commentText) + ',' + timeCommentedAgo + ',' + commentLikesCount + ',' + quoteString(pic);
     }
 


### PR DESCRIPTION
At some point the TikTok UI was changed and this stopped working; I've updated it so it works again. It also includes share count if that is listed. (Also fixed typos and the like.)

~~Note: There are now two different ways you can view TikTok comments in a web browser. The old one appears when you click a video after a search and has everything in a pop-up. The new one appears when you directly navigate to a URL or reload the page, has the comments underneath the video, and has no pop-up. Needless to say all the XPaths are different, so this will only work on the older one. (The culprit is the video URL, creator name, etc., so it's probably possible to go back to class names for those.)~~

Now works on comment lists accessed via TikTok search as well as direct URLs.

Limitations: Google Chrome will run out of memory after a loading certain amount of comments; on my machine it's about 4,000. This seems to be an inherent limitation; I've tried various ways of batching but so far have not managed to make this consistently work on larger amounts of comments.